### PR TITLE
Support warnings, and non-lint variants.

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -1,10 +1,9 @@
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
         function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
         function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
@@ -20,6 +19,15 @@ const core = __importStar(require("@actions/core"));
 const github = __importStar(require("@actions/github"));
 const fs = __importStar(require("fs"));
 const { GITHUB_TOKEN, GITHUB_WORKSPACE } = process.env;
+function getAnnotationLevel() {
+    let val = core.getInput('annotation_level');
+    if (!val) {
+        return 'failure';
+    }
+    else {
+        return val;
+    }
+}
 // Regex match each line in the output and turn them into annotations
 function parseOutput(output, regex) {
     let errors = output.split('\n');
@@ -36,14 +44,16 @@ function parseOutput(output, regex) {
             const normalized_path = groups.filename.replace('./', '');
             const line = parseInt(groups.lineNumber);
             const column = parseInt(groups.columnNumber);
-            const annotation_level = 'failure';
+            const annotation_level = (getAnnotationLevel() == 'warning') ?
+                'warning' :
+                'failure';
             const annotation = {
                 path: normalized_path,
                 start_line: line,
                 end_line: line,
                 start_column: column,
                 end_column: column,
-                annotation_level,
+                annotation_level: annotation_level,
                 message: `[${groups.errorCode}] ${groups.errorDesc}`,
             };
             annotations.push(annotation);
@@ -54,12 +64,12 @@ function parseOutput(output, regex) {
 function createCheck(check_name, title, annotations) {
     return __awaiter(this, void 0, void 0, function* () {
         const octokit = new github.GitHub(String(GITHUB_TOKEN));
-        const req = Object.assign(Object.assign({}, github.context.repo), { ref: core.getInput('commit_sha') });
+        const req = Object.assign({}, github.context.repo, { ref: core.getInput('commit_sha') });
         console.log(req);
         const res = yield octokit.checks.listForRef(req);
         console.log(res);
         const check_run_id = res.data.check_runs.filter(check => check.name === check_name)[0].id;
-        const update_req = Object.assign(Object.assign({}, github.context.repo), { check_run_id, output: {
+        const update_req = Object.assign({}, github.context.repo, { check_run_id, output: {
                 title,
                 summary: `${annotations.length} errors(s) found`,
                 annotations
@@ -78,14 +88,17 @@ function run() {
             const annotations = parseOutput(output.toString(), RegExp(regex));
             if (annotations.length > 0) {
                 console.log("===============================================================");
-                console.log("| LINT FAILURES DETECTED                                      |");
+                console.log("| FAILURES DETECTED                                           |");
                 console.log("|    You don't need to read this log output.                  |");
                 console.log("|    Check the 'Files changed' tab for in-line annotations!   |");
                 console.log("===============================================================");
                 console.log(annotations);
                 const checkName = core.getInput('check_name');
-                yield createCheck(checkName, 'lint errors detected', annotations);
-                core.setFailed(`${annotations.length} errors(s) found`);
+                yield createCheck(checkName, 'failures detected', annotations);
+                const annotation_level = getAnnotationLevel();
+                if (annotation_level != 'warning') {
+                    core.setFailed(`${annotations.length} errors(s) found`);
+                }
             }
         }
         catch (error) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,7 +9,6 @@ type Annotation = octokit.ChecksUpdateParamsOutputAnnotations;
 
 function getAnnotationLevel(): string {
     let val: string = core.getInput('annotation_level');
-    console.log("annotation_level = " + val);
     if (!val) {
         return <const>'failure';
     } else {
@@ -33,14 +32,16 @@ function parseOutput(output: string, regex: RegExp): Annotation[] {
       const normalized_path = groups.filename.replace('./', '');
       const line = parseInt(groups.lineNumber);
       const column = parseInt(groups.columnNumber);
-      const annotation_level = getAnnotationLevel();
+      const annotation_level = (getAnnotationLevel() == 'warning') ?
+        <const>'warning' :
+        <const>'failure';
       const annotation = {
         path: normalized_path,
         start_line: line,
         end_line: line,
         start_column: column,
         end_column: column,
-        annotation_level,
+        annotation_level: annotation_level,
         message: `[${groups.errorCode}] ${groups.errorDesc}`,
       };
 


### PR DESCRIPTION
In facebookresearch/ParlAI, we have a desire for one of our checks to just be warnings, and not hard errors. It's also a little different than a lint.

To support this the changes are:
- Support `annotation_level` as a flag, which can be set to warnings
- Remove some hardcoded uses of the word "lint" in the output.