### PR TITLE
Don't fail when there are warnings

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -94,10 +94,7 @@ async function run() {
       console.log(annotations);
       const checkName = core.getInput('check_name');
       await createCheck(checkName, 'failures detected', annotations);
-      const annotation_level = getAnnotationLevel();
-      if (annotation_level != 'warning') {
-        core.setFailed(`${annotations.length} errors(s) found`);
-      }
+      console.log(`${annotations.length} errors(s) found`);
     }
   }
   catch (error) {


### PR DESCRIPTION
As of https://github.com/pytorch/pytorch/pull/54779, we use this Action in a separate workflow from the "Lint" workflow that generates the warnings. Thus, it just adds noise when the job in the "Lint" workflow fails and then this job later fails after adding all the annotations to the PR. It now makes more sense for this Action to succeed as long as it successfully adds any annotations to the PR.