### PR TITLE
Only upload the first 50 annotations

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -72,7 +72,7 @@ function createCheck(check_name, title, annotations) {
         const update_req = Object.assign({}, github.context.repo, { check_run_id, output: {
                 title,
                 summary: `${annotations.length} errors(s) found`,
-                annotations
+                annotations: annotations.slice(0, 50),
             } });
         console.log(update_req);
         yield octokit.checks.update(update_req);

--- a/src/main.ts
+++ b/src/main.ts
@@ -69,7 +69,7 @@ async function createCheck(check_name: string, title: string, annotations: Annot
     output: {
       title,
       summary: `${annotations.length} errors(s) found`,
-      annotations
+      annotations: annotations.slice(0, 50),
     }
   }
 


### PR DESCRIPTION
Currently this action simply fails if more than 50 annotations are provided; example:

- https://github.com/pytorch/pytorch/runs/2274160078?check_suite_focus=true

This PR clips it at 50 so that as many as possible get added, but the logs and the `summary` still say the total number of annotations that were given.